### PR TITLE
Add automated release with GitHub Actions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,10 +21,9 @@ jobs:
           cat tmp1.tsv | sed -e "s/\"Q//" | sed -e "s/\"//g" | grep -v "wikidata" | sort -n | sed -e 's/^/Q/' | split -l 12500 -d -a 3 - inchikeys_
           rename 's/(.*)/$1.tsv/' inchikeys_*
           mv inchikeys_* inchikeys/.
-          rm tmp1.tsv
       - name: Commit files
         run: |
-          git add --all
+          git add inchikeys
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -m "Automatically update" -a

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,3 +33,15 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
+      - name: Get current date  # see https://stackoverflow.com/questions/60942067/get-current-date-and-time-in-github-workflows
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+      - name: Prepare full file
+        run: cat tmp1.tsv | sed -e "s/\"Q//" | sed -e "s/\"//g" | grep -v "wikidata" | sort -n | sed -e 's/^/Q/' > inchikeys`date +"%Y%m%d"`.tsv
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ steps.date.outputs.date }}"
+          prerelease: false
+          title: "Release ${{ steps.date.outputs.date }}"
+          files: "inchikeys${{ steps.date.outputs.date }}.tsv"


### PR DESCRIPTION
- Automate releases using the same pattern for the tag and release title as in the first one
- Add information about current date to workflow ([ref stackoverflow](https://stackoverflow.com/questions/60942067/get-current-date-and-time-in-github-workflows))
- `rm tmp1.tsv` is removed by making the `git add` command more specific for only things inside the `inchikeys folder`

There is some shared code between generation of the full inchi file and the split files - that could be refactored but I'll leave it for a different PR